### PR TITLE
Support NAKs and pass stress test

### DIFF
--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -317,7 +317,11 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
         for ep_num, ep in self.ep_in.items():
             if self.api.in_buffer_empty(ep_num) and self.api.nak_on_endpoint(ep_num):
-                if len(self.ep_transfer_queue[ep_num]) > 0:
+                if len(self.ep_transfer_queue[ep_num]) == 0:
+                    self.connected_device.handle_nak(ep_num)
+                
+                # The queue might not be empty anymore, check immediately
+                if len(self.ep_transfer_queue[ep_num]) != 0:
                     max_packet_size = ep.max_packet_size
                     packet = self.ep_transfer_queue[ep_num][0][0:max_packet_size]
                     self.ep_transfer_queue[ep_num][0] = self.ep_transfer_queue[ep_num][0][len(packet):]
@@ -326,8 +330,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
                     if len(self.ep_transfer_queue[ep_num][0]) == 0:
                         self.ep_transfer_queue[ep_num].pop(0)
-                else:
-                    self.connected_device.handle_nak(ep_num)
 
     def handle_control_request(self):
         if not self.api.control_buffer_available():

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -90,8 +90,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         self.ep_in = {}
         self.ep_out = {}
 
-        self.legacy_mode = False  # legacy_mode is used for legacy_applets
-
         self.api = HydradancerBoard()
         self.verbose = verbose
         self.api.wait_board_ready()
@@ -124,7 +122,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
         self.connected_device = usb_device
 
-        # self.legacy_mode = isinstance(self.connected_device, USBDevice) # How can we detect this ? there are still a lot of legacy apps
         self.max_ep0_packet_size = max_packet_size_ep0
 
     def disconnect(self):
@@ -300,23 +297,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
                 else:
                     self.connected_device.handle_nak(ep_num)
 
-    # def handle_data_endpoints_legacy(self):
-    #     """
-    #     Handle IN or OUT requests on non-control endpoints for the legacy_applets
-    #     """
-    #     # process ep OUT firsts, transfer is dictated by the host, if there is data available on an ep OUT,
-    #     # it should be processed before setting new IN data
-    #     for ep_num, ep in self.ep_out.items():
-    #         if self.api.OUT_buffer_available(ep_num):
-    #             data = self.api.read(ep_num)
-    #             if data is not None:
-    #                 self.connected_device.handle_data_available(
-    #                     ep_num, data.tobytes())
-
-    #     for ep_num, ep in self.ep_in.items():
-    #         if self.api.IN_buffer_empty(ep_num):
-    #             self.connected_device.handle_nak(ep)
-
     def handle_control_request(self):
         if not self.api.CONTROL_buffer_available():
             return
@@ -366,10 +346,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
         self.handle_control_request()
 
-        if not self.legacy_mode:
-            self.handle_data_endpoints()
-            # else:  # support for old USBDevice
-            #     self.handle_data_endpoints_legacy()
+        self.handle_data_endpoints()
 
         if events is not None:
             for event in events:

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -1,7 +1,7 @@
 """
-Backend for HydraUSB3.
+Backend for the Hydradancer boards.
 
-Supports 4 high-speed endpoints, with addresses between 1 and 7.
+Supports 8 endpoints, with addresses between 0 and 7. Supports low, full and high-speed.
 """
 
 import sys
@@ -221,13 +221,13 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         max_packet_size = self.max_ep0_packet_size if endpoint_number == 0 else self.ep_in[endpoint_number].max_packet_size
 
         if not data:
-            self.api.send(endpoint_number, data, blocking)
+            self.api.send(endpoint_number, data)
 
         while data:
             packet = data[0:max_packet_size]
             data = data[len(packet):]
-            logging.debug(f"Sending {len(packet)} on ep {endpoint_number} blocking {blocking}")
-            self.api.send(endpoint_number, packet, blocking)
+            logging.debug(f"Sending {len(packet)} on ep {endpoint_number}")
+            self.api.send(endpoint_number, packet)
 
         # Many things to take into account here ...
         # first, if the len we are sending is a multiple of the max_packet_size, the host will request a ZLP (otherwise, it can't know when the transfer ends)
@@ -236,7 +236,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         # however, this could add too much latency and make enumeration fail
         if endpoint_number == 0 and (backup_len % max_packet_size) == 0 and backup_len > 0 and backup_len != self.current_setup_req.length:
             logging.debug(f"Sending ZLP")
-            self.api.send(endpoint_number, b"", blocking) # Sending ZLP
+            self.api.send(endpoint_number, b"") # Sending ZLP
 
     def ack_status_stage(self, direction: USBDirection=USBDirection.OUT, endpoint_number:int =0, blocking: bool=False):
         """
@@ -313,7 +313,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
                     packet = self.ep_transfer_queue[ep_num][0][0:max_packet_size]
                     self.ep_transfer_queue[ep_num][0] = self.ep_transfer_queue[ep_num][0][len(packet):]
 
-                    self.api.send(ep_num, packet, blocking = True)
+                    self.api.send(ep_num, packet)
 
                     if len(self.ep_transfer_queue[ep_num][0]) == 0:
                         self.ep_transfer_queue[ep_num].pop(0)
@@ -371,11 +371,11 @@ class HydradancerBoard():
     """
     Handles the communication with the Hydradancer control board and manages the events it sends.
     """
-    MAX_PACKET_SIZE = 512
+    MAX_PACKET_SIZE = 1024
 
     # USB Vendor Requests codes
-    ENABLE_USB_CONNECTION_REQUEST_CODE = 50
-    SET_ADDRESS_REQUEST_CODE = 51
+    ENABLE_USB_CONNECTION = 50
+    SET_ADDRESS = 51
     GET_EVENT = 52
     SET_ENDPOINT_MAPPING = 53
     DISABLE_USB = 54
@@ -385,16 +385,15 @@ class HydradancerBoard():
     DO_BUS_RESET = 58
     CONFIGURED = 59
 
-    #  events offsets
-    HYDRADANCER_STATUS_BUS_RESET = 0x1
-
     # Facedancer USB2 speed to Hydradancer USB2 speed
     facedancer_to_hydradancer_speed = {
         DeviceSpeed.LOW : 0,
         DeviceSpeed.FULL : 1,
         DeviceSpeed.HIGH : 2
     }
-
+    
+    # Max number of events that can be sent by the board
+    # This must not be less than what is defined in the firmware
     EVENT_QUEUE_SIZE = 100
 
     # Endpoint states on the emulation board
@@ -525,7 +524,7 @@ class HydradancerBoard():
         """
         try:
             self.device.ctrl_transfer(
-                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.ENABLE_USB_CONNECTION_REQUEST_CODE)
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.ENABLE_USB_CONNECTION)
         except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
             logging.error(exception)
             raise HydradancerBoardFatalError("Error, unable to connect") from exception
@@ -631,7 +630,7 @@ class HydradancerBoard():
         """
         try:
             self.device.ctrl_transfer(
-                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.SET_ADDRESS_REQUEST_CODE, address)
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.SET_ADDRESS, address)
         except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
             logging.error(exception)
             raise HydradancerBoardFatalError(
@@ -641,8 +640,6 @@ class HydradancerBoard():
         """
         Stall the ep_num endpoint on the emulation board.
         STALL will be cleared automatically after next SETUP packet received.
-        Currently stalls both directions, because ep0 was STALLED only in one direction
-        (TODO maybe separate ep0 from the rest, and double-check).
         """
         # Stall EP
 
@@ -659,12 +656,11 @@ class HydradancerBoard():
             logging.error(exception)
             raise HydradancerBoardFatalError(f"Could not stall ep {ep_num}") from exception
 
-    def send(self, ep_num, data, blocking=False):
+    def send(self, ep_num, data):
         """
-        Prime target endpoint ep_num. If blocking=True, it will wait for the endpoint's buffer to be empty.
+        Prime target endpoint ep_num.
         """
         try:
-            count = 0
             start_time = time_ns()
             MAX_TIME_NS = 1e-3 * 1e9 
             while not (self.in_buffer_empty(ep_num) and (ep_num == 0)) and not (ep_num != 0 and self.nak_on_endpoint(ep_num) and self.in_buffer_empty(ep_num)):
@@ -709,18 +705,18 @@ class HydradancerBoard():
         if len(endpoint_numbers) > len(self.endpoints_pool):
             raise HydradancerBoardFatalError(
                 f"Hydradancer cannot handle {len(endpoint_numbers)} endpoints, only {len(self.endpoints_pool)}")
-        for number in endpoint_numbers:
-            self.set_endpoint_mapping(number)
         try:
+            for number in endpoint_numbers:
+                self.set_endpoint_mapping(number)
             self.device.ctrl_transfer(CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT,
                                     self.CONFIGURED)
+            logging.info(f"Endpoints mapping {self.endpoints_mapping}")
+            self.configured = True
         except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
             logging.error(exception)
             raise HydradancerBoardFatalError(
                 "Could not pass configured step on board") from exception
-                
-        logging.info(f"Endpoints mapping {self.endpoints_mapping}")
-        self.configured = True
+
 
     def fetch_events(self):
         """

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -290,7 +290,16 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
                 if event is None:
                     continue
                 if event.event_type == HydradancerEvent.EVENT_BUS_RESET:
-                    self.reset()
+                    self.handle_bus_reset()
+
+    def handle_bus_reset(self):
+        """
+        Triggers Hydradancer to perform its side of a bus reset.
+        """
+        if self.connected_device:
+            self.connected_device.handle_bus_reset()
+        else:
+            self.reset()
 
     def handle_data_endpoints(self):
         """

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -214,7 +214,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         """
         if endpoint_number != 0 and not blocking:
             logging.debug(f"Storing {len(data)} on ep {endpoint_number} for later")
-            self.ep_transfer_queue[endpoint_number].append([data, len(data)])
+            self.ep_transfer_queue[endpoint_number].append(data)
             return
 
         backup_len = len(data)
@@ -310,12 +310,12 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
             if self.api.in_buffer_empty(ep_num) and self.api.nak_on_endpoint(ep_num):
                 if len(self.ep_transfer_queue[ep_num]) > 0:
                     max_packet_size = ep.max_packet_size
-                    packet = self.ep_transfer_queue[ep_num][0][0][0:max_packet_size]
-                    self.ep_transfer_queue[ep_num][0][0] = self.ep_transfer_queue[ep_num][0][0][len(packet):]
+                    packet = self.ep_transfer_queue[ep_num][0][0:max_packet_size]
+                    self.ep_transfer_queue[ep_num][0] = self.ep_transfer_queue[ep_num][0][len(packet):]
 
                     self.api.send(ep_num, packet, blocking = True)
 
-                    if len(self.ep_transfer_queue[ep_num][0][0]) == 0:
+                    if len(self.ep_transfer_queue[ep_num][0]) == 0:
                         self.ep_transfer_queue[ep_num].pop(0)
                 else:
                     self.connected_device.handle_nak(ep_num)

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -298,7 +298,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
                     if len(self.ep_transfer_queue[ep_num][0][0]) == 0:
                         self.ep_transfer_queue[ep_num].pop(0)
                 else:
-                    self.connected_device.handle_data_requested(ep)
+                    self.connected_device.handle_nak(ep_num)
 
     # def handle_data_endpoints_legacy(self):
     #     """

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -10,13 +10,13 @@ import time
 from array import array
 from time import time_ns
 from dataclasses import dataclass
-from typing import List
+from typing import List, Dict, Any
 
 import usb
 from usb.util import CTRL_TYPE_VENDOR, CTRL_RECIPIENT_DEVICE, CTRL_IN, CTRL_OUT
 
 from ..core           import *
-from ..device         import USBDevice, USBConfiguration, USBDirection
+from ..device         import USBDevice, USBConfiguration, USBDirection, USBEndpoint
 from ..types          import DeviceSpeed
 from ..logging        import log
 from .base            import FacedancerBackend
@@ -73,10 +73,10 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         self.connected_device = None
         self.max_ep0_packet_size = None
 
-        self.ep_transfer_queue = [[]] * self.USB2_MAX_EP_IN
+        self.ep_transfer_queue : List[List[Any]] = [[]] * self.USB2_MAX_EP_IN
 
-        self.ep_in = {}
-        self.ep_out = {}
+        self.ep_in : Dict[int, USBEndpoint] = {}
+        self.ep_out : Dict[int, USBEndpoint] = {}
 
         self.api = HydradancerBoard()
         self.verbose = verbose
@@ -137,7 +137,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         self.configuration = None
         self.pending_control_out_request = None
         self.connected_device = None
-        self.max_ep0_packet_size = None
+        self.max_ep0_packet_size = 0
         self.ep_transfer_queue = [[]] * self.USB2_MAX_EP_IN
         self.api.disconnect()
 
@@ -436,7 +436,7 @@ class HydradancerBoard():
         Get handles on the USB control board, and wait for Hydradancer to be ready
         """
         self.configured = False
-        self.endpoints_mapping = {}
+        self.endpoints_mapping : Dict[int,int] = {}
 
         self.reinit()
 

--- a/facedancer/filters/standard.py
+++ b/facedancer/filters/standard.py
@@ -67,7 +67,8 @@ class USBProxySetupFilters(USBProxyFilter):
         # handle it ourself, and absorb it.
         if req.get_recipient() == self.RECIPIENT_DEVICE and \
            req.request == self.SET_ADDRESS_REQUEST:
-            self.device.handle_set_address_request(req)
+            req.acknowledge(blocking=True)
+            self.device.set_address(req.value)
             return None, None
 
         # Special case: if this is a SET_CONFIGURATION_REQUEST,

--- a/test/speedtest_fullspeed.py
+++ b/test/speedtest_fullspeed.py
@@ -66,6 +66,18 @@ class USBSpeedtest(USBDevice):
         print(f"sending {len(self.random_buffer)} bytes on {ep}")
         self.send(ep.number, self.random_buffer)
 
+    def handle_buffer_empty(self, endpoint: USBEndpoint):
+        """ Handler called when a given endpoint first has an empty buffer.
+
+        Often, an empty buffer indicates an opportunity to queue data
+        for sending ('prime an endpoint'), but doesn't necessarily mean
+        that the host is planning on reading the data.
+
+        This function is called only once per buffer.
+        """
+        print(f"priming {len(self.random_buffer)} bytes on {endpoint}")
+        self.send(endpoint.number, self.random_buffer)
+
 
 if __name__ == "__main__":
     default_main(USBSpeedtest)

--- a/test/speedtest_highspeed.py
+++ b/test/speedtest_highspeed.py
@@ -99,6 +99,17 @@ class USBSpeedtest(USBDevice):
         print(f"sending {len(self.random_buffer)} bytes on {ep}")
         self.send(ep.number, self.random_buffer)
 
+    def handle_buffer_empty(self, endpoint: USBEndpoint):
+        """ Handler called when a given endpoint first has an empty buffer.
+
+        Often, an empty buffer indicates an opportunity to queue data
+        for sending ('prime an endpoint'), but doesn't necessarily mean
+        that the host is planning on reading the data.
+
+        This function is called only once per buffer.
+        """
+        print(f"priming {len(self.random_buffer)} bytes on {endpoint}")
+        self.send(endpoint.number, self.random_buffer)
 
 if __name__ == "__main__":
     default_main(USBSpeedtest)


### PR DESCRIPTION
Various changes to handle NAKs, to make both the regular and highly stressed stress test pass. The highly stressed version still has very rare errors due to missed interruptions, which should happen even less in normal use.

Since we are handling NAKs now, switched to using `handle_nak` : usbproxy now works, tested with a mouse in full-speed and mass-storage in high-speed ! 

Cleaned up the code using pylint and mypy, matched the backend function declarations.